### PR TITLE
Fixed typographical error, changed absolutly to absolutely in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -231,7 +231,7 @@ _notify.yml_
 But this code creates a hard coded relation between your code and the plugin isn't it? 
 It can be done this way but it is not a good idea. 
 So how can we do it better?
-Below we are sending absolutly the same message using sfEventDispatcher:
+Below we are sending absolutely the same message using sfEventDispatcher:
     
     <?php
     


### PR DESCRIPTION
@makasim, I've corrected a typographical error in the documentation of the [fpErrorNotifierPlugin](https://github.com/makasim/fpErrorNotifierPlugin) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.